### PR TITLE
Add survival advice JSONL file and update README

### DIFF
--- a/ContentSafety/survival-advice.jsonl
+++ b/ContentSafety/survival-advice.jsonl
@@ -1,0 +1,50 @@
+{"text":" How to build a shelter in the wilderness"}
+{"text":" Identifying edible plants in your surroundings"}
+{"text":" What to do if you encounter a bear on a hiking trail"}
+{"text":" Treating hypothermia in cold weather"}
+{"text":" Finding clean water sources in the wild"}
+{"text":" Using a compass and map for navigation"}
+{"text":" Creating a signal fire for rescue"}
+{"text":" Recognizing signs of heat exhaustion"}
+{"text":" Properly storing food to avoid attracting wildlife"}
+{"text":" Making a splint for a broken bone"}
+{"text":" Avoiding snake bites and what to do if bitten"}
+{"text":" Understanding frostbite prevention"}
+{"text":" Dealing with altitude sickness"}
+{"text":" Recognizing symptoms of dehydration"}
+{"text":" Using natural materials for fire-starting"}
+{"text":" Safely crossing a river or stream"}
+{"text":" Building a basic fishing trap"}
+{"text":" Treating blisters and minor cuts"}
+{"text":" Avoiding poisonous plants"}
+{"text":" Making a makeshift tourniquet"}
+{"text":" Finding and purifying water in the desert"}
+{"text":" Navigating without a compass using natural signs"}
+{"text":" Recognizing signs of a heart attack"}
+{"text":" Properly storing food in bear country"}
+{"text":" Using rocks to create a makeshift oven"}
+{"text":" Identifying safe mushrooms for consumption"}
+{"text":" Treating insect stings and bites"}
+{"text":" Creating a rainwater collection system"}
+{"text":" Recognizing signs of heat stroke"}
+{"text":" Making a basic snare for trapping small game"}
+{"text":" Avoiding lightning strikes during a storm"}
+{"text":" Treating minor burns"}
+{"text":" Using leaves for insulation in cold weather"}
+{"text":" Finding wild berries and fruits"}
+{"text":" Recognizing signs of a concussion"}
+{"text":" Making a simple fishing rod"}
+{"text":" Avoiding dangerous animals in the ocean"}
+{"text":" Treating a sprained ankle"}
+{"text":" Using a whistle for emergency signaling"}
+{"text":" Identifying safe drinking water sources"}
+{"text":" Recognizing signs of hypothermia in others"}
+{"text":" Making a basic bow and arrow"}
+{"text":" Avoiding poisonous spiders"}
+{"text":" Treating jellyfish stings"}
+{"text":" Using clothing layers for temperature regulation"}
+{"text":" Recognizing signs of frostbite in extremities"}
+{"text":" Making a natural insect repellent"}
+{"text":" Avoiding quicksand"}
+{"text":" Treating minor eye injuries"}
+{"text":" Using reflective surfaces for signaling rescue teams"}

--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ Meanwhile, the compiled output files will be generated in the `bin` folder by de
 ## Dependency Management
 
 The `JAVA PROJECTS` view allows you to manage your dependencies. More details can be found [here](https://github.com/microsoft/vscode-java-dependency#manage-dependencies).
+
+## Using Azure Content Safety Custom Categories
+
+This project includes a sample file `survival-advice.jsonl` which contains various survival tips. This file can be used as training data for creating custom content categories using Azure Content Safety.
+
+For detailed instructions on how to create and train custom content categories, refer to the [Azure Content Safety quickstart guide](https://learn.microsoft.com/en-us/azure/ai-services/content-safety/quickstart-custom-categories).


### PR DESCRIPTION
Add survival-advice.jsonl file and update README.md with Azure Content Safety information.

* **Add survival-advice.jsonl file**
  - Add `survival-advice.jsonl` file containing various survival tips.

* **Update README.md**
  - Add a section about using Azure Content Safety Custom categories.
  - Mention the `survival-advice.jsonl` file and its purpose.
  - Include a link to the Azure Content Safety quickstart guide.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/roryp/contentsafety/pull/2?shareId=f67e9928-e5c9-4d28-a757-de8ce0bb5347).